### PR TITLE
Feature/heroku metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ Default output folder is `src/Golad/bin/Debug/netcoreapp1.1/publish/`.
 
 More info about publish command [here](https://docs.microsoft.com/en-us/dotnet/articles/core/tools/dotnet-publish).
 
+#### Deploying for fun
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/deltaidea/golad)
+
+This is completely free.
+
+Go to the app settings and change automatic deploys to use your fork if you want.
+
 ## API Reference
 
 No public API exists yet.

--- a/app.json
+++ b/app.json
@@ -1,0 +1,19 @@
+{
+  "name": "Game of Life and Death",
+  "description": "An implementation of the Game of Life and Death in .NET Core and React.",
+  "repository": "https://github.com/deltaidea/golad",
+  "stack": "heroku-16",
+  "buildpacks": [
+    {"url": "heroku/nodejs"},
+    {"url": "https://github.com/jincod/dotnetcore-buildpack"}
+  ],
+  "addons": [
+    {"plan": "cleardb:ignite", "as": "CLEARDB_DATABASE"}
+  ],
+  "formation": {
+    "web": {
+      "quantity": 1,
+      "size": "free"
+    }
+  }
+}

--- a/app.json
+++ b/app.json
@@ -5,7 +5,7 @@
   "stack": "heroku-16",
   "buildpacks": [
     {"url": "heroku/nodejs"},
-    {"url": "https://github.com/jincod/dotnetcore-buildpack"}
+    {"url": "https://github.com/jincod/dotnetcore-buildpack.git#heroku-16"}
   ],
   "addons": [
     {"plan": "cleardb:ignite", "as": "CLEARDB_DATABASE"}


### PR DESCRIPTION
This saves all deployment info to the repo and adds a button to README that allows to deploy a new instance with a single click.

Example deployed from this branch using the button: http://game-of-life-and-death.herokuapp.com/