### PR TITLE
fix(appveyor.yml): skip branches with open PRs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,3 +18,6 @@ test_script:
 
 # Don't actually build.
 build: off
+
+# Don't build a branch if there's a PR from it.
+skip_branch_with_pr: true


### PR DESCRIPTION
AppVeyor is free for us, let's be nice and skip unnecessary builds.